### PR TITLE
Use 'live' instead of 'continuous' keyword

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -63,11 +63,11 @@
     syncDom.setAttribute('data-sync-state', 'syncing');
     var remote = new PouchDB(remoteCouch, {headers: {'Cookie': cookie}});
     var pushRep = db.replicate.to(remote, {
-      continuous: true,
+      live: true,
       complete: syncError
     });
     var pullRep = db.replicate.from(remote, {
-      continuous: true,
+      live: true,
       complete: syncError
     });
   }


### PR DESCRIPTION
I think 'live' is the correct way to sync continuously. Was `continuous` perhaps used in an older version of pouchDB?

On second look, it appears that you are using pouchdb.nightly from 2013-07. The newer version does support `continuous`. In fact, it supersedes any usage of `live`.

Not sure what you'll want to do, but might as well start a conversation. PouchDB documentation says to use `live` to sync continuously, but technically they both work with the newer version.